### PR TITLE
Url index length

### DIFF
--- a/lib/generators/shortener/templates/migration.rb
+++ b/lib/generators/shortener/templates/migration.rb
@@ -26,7 +26,7 @@ class CreateShortenedUrlsTable < ActiveRecord::Migration
     # we will lookup the links in the db by key, urls and owners.
     # also make sure the unique keys are actually unique
     add_index :shortened_urls, :unique_key, unique: true
-    add_index :shortened_urls, :url
+    add_index :shortened_urls, :url, length: 200
     add_index :shortened_urls, [:owner_id, :owner_type]
     add_index :shortened_urls, :category
   end


### PR DESCRIPTION
Without length it generates error like a:
Mysql2::Error: BLOB/TEXT column 'url' used in key specification without a key length: CREATE  INDEX `index_shortened_urls_on_url`  ON `shortened_urls` (`url`)